### PR TITLE
added directive to support cmd-s and ctrl-s

### DIFF
--- a/src/js/angular/dfx.vieweditor.app.js
+++ b/src/js/angular/dfx.vieweditor.app.js
@@ -20,6 +20,10 @@ dfxViewEditorApp.controller("dfx_main_controller", [ '$scope', '$rootScope', '$q
     $scope.helpForm = false;
     $scope.scopeOptionsVarNameInput = false;
 
+	$scope.$on('keypress:83', function(onEvent, keypressEvent) {
+    	alert('here');
+    });
+
     $scope.getGCDefaultAttributes = function( type ) {
         var deferred = $q.defer();
         if ($scope.gc_types[type] != null) {
@@ -359,6 +363,8 @@ dfxViewEditorApp.controller("dfx_view_editor_controller", [ '$scope', '$rootScop
         $('#dfx_script_editor').css('display', 'block');
         $('.dfx-ve-toolbar-button').removeClass('dfx-ve-toolbar-button-selected');
         $('.dfx-ve-toolbar-button-script').addClass('dfx-ve-toolbar-button-selected');
+		var editor = $('#dfx_script_editor')[0].CodeMirror;
+		editor.focus();
     };
     $scope.showStyle = function() {
         $scope.design_visible = false;
@@ -370,6 +376,8 @@ dfxViewEditorApp.controller("dfx_view_editor_controller", [ '$scope', '$rootScop
         $('#dfx_styles_editor').css('display', 'block');
         $('.dfx-ve-toolbar-button').removeClass('dfx-ve-toolbar-button-selected');
         $('.dfx-ve-toolbar-button-styles').addClass('dfx-ve-toolbar-button-selected');
+		var editor = $('#dfx_styles_editor')[0].CodeMirror;
+		editor.focus();
     };
     $scope.showSource = function() {
         var editor = $('#dfx_src_editor')[0].CodeMirror;
@@ -386,6 +394,7 @@ dfxViewEditorApp.controller("dfx_view_editor_controller", [ '$scope', '$rootScop
             editor.setValue(JSON.stringify(widget_definition, null, '\t'));
             editor.scrollTo(0, 0);
             editor.refresh();
+			editor.focus();
         }
 
         $scope.design_visible = false;
@@ -702,7 +711,9 @@ dfxViewEditorApp.controller("dfx_view_editor_controller", [ '$scope', '$rootScop
 
 
     $scope.saveView = function(event) {
-        $(event.srcElement).animateCss('pulse');
+		if (event!=null) {
+        	$(event.srcElement).animateCss('pulse');
+		}
         /*DfxStudio.updateWidgetSource({
             widgetName:'#{widget.name}',
             category:'#{widget.category}',
@@ -4763,3 +4774,19 @@ var helpDialogScript = function (options) {
         $('#dfx_visual_editor_help_close').click();
     }
 };
+
+dfxViewEditorApp.directive('dfxVeCtrlS', [ '$document', function ($document) {
+	return {
+      restrict: 'A',
+      link: function(scope) {
+        $document.bind('keydown', function(e) {
+			if ((e.which == '115' || e.which == '83' ) && (e.ctrlKey || e.metaKey)) {
+				e.preventDefault();
+				scope.saveView();
+				return false;
+		    }
+		    return true;
+        });
+      }
+    };
+}]);

--- a/src/js/visualbuilder/dfx.visualbuilder.js
+++ b/src/js/visualbuilder/dfx.visualbuilder.js
@@ -130,7 +130,10 @@ DfxVisualBuilder.init = function () {
             highlightSelectionMatches: {showToken: /\w/},
             styleActiveLine: true,
             viewportMargin : Infinity,
-            extraKeys: {"Alt-F": "findPersistent", "Ctrl-Space": "autocomplete"},
+            extraKeys: {
+				"Alt-F": "findPersistent",
+				"Ctrl-Space": "autocomplete"
+			},
             foldGutter: true,
             gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
         });
@@ -153,7 +156,10 @@ DfxVisualBuilder.init = function () {
             highlightSelectionMatches: {showToken: /\w/},
             styleActiveLine: true,
             viewportMargin : Infinity,
-            extraKeys: {"Alt-F": "findPersistent", "Ctrl-Space": "autocomplete"},
+            extraKeys: {
+				"Alt-F": "findPersistent",
+				"Ctrl-Space": "autocomplete"
+			},
             foldGutter: true,
             gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
         });
@@ -176,7 +182,10 @@ DfxVisualBuilder.init = function () {
             highlightSelectionMatches: {showToken: /\w/},
             styleActiveLine: true,
             viewportMargin : Infinity,
-            extraKeys: {"Alt-F": "findPersistent", "Ctrl-Space": "autocomplete"},
+            extraKeys: {
+				"Alt-F": "findPersistent",
+				"Ctrl-Space": "autocomplete"
+			},
             foldGutter: true,
             gutters: ["CodeMirror-linenumbers", "CodeMirror-foldgutter"]
         });

--- a/templates/studio/widgets/view_visual_editor.jade
+++ b/templates/studio/widgets/view_visual_editor.jade
@@ -1,4 +1,4 @@
-div#dfx_src_widget_editor(ng-controller="dfx_view_editor_controller", layout="column", flex, style="height:100%;", data-view-cat="#{widget.category}", data-view-platform="#{widget.platform}")
+div#dfx_src_widget_editor(ng-controller="dfx_view_editor_controller", dfx-ve-ctrl-s="saveView()", layout="column", flex, style="height:100%;", data-view-cat="#{widget.category}", data-view-platform="#{widget.platform}")
     div#dfx-ve-header
         img(src="/images/df_logo_blanc_1029x223.png", style="width: 90px;margin-top: -3px;margin-left:10px;")
         div(style="color: #fff;font-size: 13px;font-style: italic;display: inline-block;") - View Editor


### PR DESCRIPTION
The view editor can now save the view using cmd-s or ctrl-s. The directive is generic, it can be applied to other editor (page editor or API SO editor).